### PR TITLE
Fixes "chmod: invalid mode: ‘0o644’" exception

### DIFF
--- a/fabtools/require/files.py
+++ b/fabtools/require/files.py
@@ -190,7 +190,7 @@ def file(path=None, contents=None, source=None, url=None, md5=None,
 
     # Ensure correct mode
     if use_sudo and mode is None:
-        mode = oct(0o666 & ~int(umask(use_sudo=True), base=8))
+        mode = "%o" % (0o666 & ~int(umask(use_sudo=True), base=8))
     if mode and _mode(path, use_sudo) != mode:
         func('chmod %(mode)s "%(path)s"' % locals())
 


### PR DESCRIPTION
oct() generates "0o644"-like strings, while stat() inside _mode() gives simple "644"-like ones.
Fix is needed to make comparison and chmod command to work.